### PR TITLE
Fix Jinja escaping in blob callback

### DIFF
--- a/src/retrocookie/filter.py
+++ b/src/retrocookie/filter.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from typing import Any
 from typing import Container
 from typing import Dict
+from typing import Iterator
 from typing import List
+from typing import overload
+from typing import Sequence
 from typing import Tuple
 
 from git_filter_repo import Blob
@@ -22,14 +25,60 @@ def get_replacements(
     def ref(key: str) -> str:
         return f"{{{{ cookiecutter.{key} }}}}"
 
-    escape = [(token, token.join(('{{ "', '" }}'))) for token in ("{{", "}}")]
-    replacements = [
+    return [
         (value, ref(key))
         for key, value in context.items()
         if key not in blacklist and not (whitelist and key not in whitelist)
     ]
 
-    return escape + replacements
+
+def quote_tokens(
+    text: bytes, quotes: Tuple[bytes, bytes], tokens: Sequence[bytes]
+) -> bytes:
+    """Wrap tokens in ``<quotes[0]><token><quotes[1]>``."""
+
+    def _generate() -> Iterator[bytes]:
+        index = 0
+
+        while index < len(text):
+            for token in tokens:
+                found = text.find(token, index)
+                if found != -1:
+                    break
+
+            if found == -1:
+                yield text[index:]
+                break
+
+            if found != 0:
+                yield text[index:found]
+
+            yield token.join(quotes)
+            index = found + len(token)
+
+    return b"".join(_generate())
+
+
+@overload
+def to_bytes(args: Tuple[str, str]) -> Tuple[bytes, bytes]:  # noqa: D103
+    ...  # pragma: no cover
+
+
+@overload
+def to_bytes(args: Tuple[str, ...]) -> Tuple[bytes, ...]:  # noqa: D103
+    ...  # pragma: no cover
+
+
+def to_bytes(args: Tuple[str, ...]) -> Tuple[bytes, ...]:
+    """Convert each str to bytes."""
+    return tuple(arg.encode() for arg in args)
+
+
+def escape_jinja(text: bytes) -> bytes:
+    """Escape Jinja tokens."""
+    quotes = to_bytes(('{{ "', '" }}'))
+    tokens = to_bytes(("{{", "}}"))
+    return quote_tokens(text, quotes, tokens)
 
 
 class RepositoryFilter:
@@ -59,6 +108,7 @@ class RepositoryFilter:
 
     def blob_callback(self, blob: Blob, metadata: Dict[str, Any]) -> None:
         """Rewrite blobs."""
+        blob.data = escape_jinja(blob.data)
         for old, new in self.replacements:
             blob.data = blob.data.replace(old, new)
 

--- a/src/retrocookie/filter.py
+++ b/src/retrocookie/filter.py
@@ -19,14 +19,14 @@ from . import utils
 
 def get_replacements(
     context: Dict[str, str], whitelist: Container[str], blacklist: Container[str],
-) -> List[Tuple[str, str]]:
+) -> List[Tuple[bytes, bytes]]:
     """Return replacements to be applied to commits from the template instance."""
 
     def ref(key: str) -> str:
         return f"{{{{ cookiecutter.{key} }}}}"
 
     return [
-        (value, ref(key))
+        (value.encode(), ref(key).encode())
         for key, value in context.items()
         if key not in blacklist and not (whitelist and key not in whitelist)
     ]
@@ -95,10 +95,7 @@ class RepositoryFilter:
         """Initialize."""
         self.repository = repository
         self.path = str(path).encode()
-        self.replacements = [
-            (old.encode(), new.encode())
-            for old, new in get_replacements(context, whitelist, blacklist)
-        ]
+        self.replacements = get_replacements(context, whitelist, blacklist)
 
     def filename_callback(self, filename: bytes) -> bytes:
         """Rewrite filenames."""

--- a/src/retrocookie/filter.py
+++ b/src/retrocookie/filter.py
@@ -77,7 +77,7 @@ def to_bytes(args: Tuple[str, ...]) -> Tuple[bytes, ...]:
 def escape_jinja(text: bytes) -> bytes:
     """Escape Jinja tokens."""
     quotes = to_bytes(('{{ "', '" }}'))
-    tokens = to_bytes(("{{", "}}"))
+    tokens = to_bytes(("{{", "}}", "{%", "%}", "{#", "#}"))
     return quote_tokens(text, quotes, tokens)
 
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,18 @@
+"""Tests for filter module."""
+import pytest
+
+from retrocookie.filter import escape_jinja
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("", ""),
+        ("{{}}", '{{ "{{" }}{{ "}}" }}'),
+        ("${{ matrix.os }}", '${{ "{{" }} matrix.os {{ "}}" }}'),
+        ("lorem {# ipsum #} dolor", 'lorem {{ "{#" }} ipsum {{ "#}" }} dolor'),
+    ],
+)
+def test_escape_jinja(text: str, expected: str) -> None:
+    """It returns the expected result."""
+    assert expected == escape_jinja(text.encode()).decode()


### PR DESCRIPTION
The current algorithm has a bug where replacements are performed on the replacement text itself:

```
  {{ text }}
  => {{ "{{" }} text }}                  # escaping `{{`
  => {{ "{{" {{ "}}" }} text {{ "}}" }}  # escaping `}}`
```

Move the Jinja escaping to a separate function `escape_jinja`, which avoids overlapping replacements. The implementation uses two helper functions, `quote_tokens` and `to_bytes`.

Escape Jinja tokens for statements and comments:

```jinja2
{% statement %}
{# comment #}
```