### PR TITLE
Replace --url option by a positional argument

### DIFF
--- a/src/retrocookie/__main__.py
+++ b/src/retrocookie/__main__.py
@@ -10,13 +10,6 @@ from .core import retrocookie
 
 @click.command()
 @click.option(
-    "--url",
-    metavar="URL",
-    help=(
-        "Repository URL of template instance" "  [default: <originurl>-instance.git]"
-    ),
-)
-@click.option(
     "--ref", "-r", metavar="REF", required=True, help="Remote reference to fetch",
 )
 @click.option(
@@ -46,23 +39,30 @@ from .core import retrocookie
 @click.option(
     "--directory", "-C", metavar="DIR", help="Repository directory",
 )
+@click.argument("repository", required=False)
 @click.version_option()
 def main(
-    url: Optional[str],
     ref: str,
     base: str,
     local: Optional[str],
     whitelist: Container[str],
     blacklist: Container[str],
     directory: Optional[str],
+    repository: Optional[str],
 ) -> None:
-    """Retrocookie imports commits into Cookiecutter templates."""
+    """Retrocookie imports commits into Cookiecutter templates.
+
+    The source repository is passed as a non-optional argument. This can
+    be the repository URL or filesystem path of an instance of the
+    Cookiecutter template. If omitted, the repository URL is constructed
+    from origin, by appending `-instance` to the repository name.
+    """
     path = Path(directory) if directory else None
     retrocookie(
         ref,
         base=base,
         branch=local,
-        url=url,
+        url=repository,
         whitelist=whitelist,
         blacklist=blacklist,
         path=path,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,7 +46,7 @@ def test_main(
     with utils.chdir(cookiecutter.path):
         result = runner.invoke(
             __main__.main,
-            ["--ref=topic", f"--url={instance.path}", *options],
+            ["--ref=topic", *options, str(instance.path)],
             catch_exceptions=False,
         )
         assert result.exit_code == 0


### PR DESCRIPTION
The source repository can be a local directory, so a positional argument seems a good fit, and `--url` is actually a misnomer.