### PR TITLE
Configure darglint to allow long docstrings without signatures

### DIFF
--- a/.darglint
+++ b/.darglint
@@ -1,2 +1,2 @@
 [darglint]
-strictness = short
+strictness = long


### PR DESCRIPTION
This is mostly required to allow for long docstrings for click commands without redundant parameter descriptions (these would duplicate help strings from the option decorators). Ignoring this warning in a line-based way seems tricky or impossible, without the comment being displayed in the command-line help text. Another way would be a per-file ignore, but this could mask actual issues with other functions in the `__main__` module.