### PR TITLE
Use __future__.annotations instead of quoting return types

### DIFF
--- a/src/retrocookie/git.py
+++ b/src/retrocookie/git.py
@@ -1,4 +1,6 @@
 """Git interface."""
+from __future__ import annotations
+
 import subprocess  # noqa: S404
 from pathlib import Path
 from typing import Any
@@ -19,22 +21,20 @@ class Repository:
 
     def git(
         self, *args: str, check: bool = True, **kwargs: Any
-    ) -> "subprocess.CompletedProcess[str]":
+    ) -> subprocess.CompletedProcess[str]:
         """Invoke git."""
-        # FIXME: Use `from __future__ import annotations` instead of quoting.
-        # This requires Python 3.7+.
         return subprocess.run(  # noqa: S603,S607
             ["git", *args], check=check, cwd=self.path, **kwargs
         )
 
     @classmethod
-    def init(cls, path: Path) -> "Repository":
+    def init(cls, path: Path) -> Repository:
         """Create a repository."""
         repo = pygit2.init_repository(path)
         return cls(path, repo=repo)
 
     @classmethod
-    def clone(cls, url: str, path: Path) -> "Repository":
+    def clone(cls, url: str, path: Path) -> Repository:
         """Clone the repository."""
         # pygit2 wheels for Windows and macOS lack SSH support.
         # https://github.com/libgit2/pygit2/issues/994


### PR DESCRIPTION
Use postponed evaluation of type annotations, as specified in [PEP 563]. This allows us to remove quotes from types in two cases:

- Return types of class methods which return instances of the class being defined
- Generic types which are also (non-generic) classes, like `subprocess.CompletedProcess`

[PEP 563]: https://www.python.org/dev/peps/pep-0563/

This solves the issue where `subprocess.CompletedProcess` must be subscripted by `str` according to typeshed, but this leads to a runtime error because the class -- as defined in `subprocess` -- cannot be subscripted.