### PR TITLE
Rework cherry picking implementation

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -28,7 +28,7 @@ ignore_missing_imports = True
 [mypy-git_filter_repo]
 ignore_missing_imports = True
 
-[mypy-pygit2]
+[mypy-pygit2.*]
 ignore_missing_imports = True
 
 [mypy-pytest]

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -72,9 +72,10 @@ def apply_commits(
 
     if create_branch:
         repository.create_branch(create_branch)
+        repository.switch_branch(create_branch)
 
     for commit in commits:
-        repository.cherrypick(commit, branch=create_branch)
+        repository.cherrypick(commit)
 
 
 def retrocookie(

--- a/src/retrocookie/git.py
+++ b/src/retrocookie/git.py
@@ -132,10 +132,10 @@ class Repository:
 
         self.repo.create_commit(refname, author, committer, message, tree, parents)
 
-    def cherrypick(self, ref: str, *, branch: Optional[str] = None) -> None:
-        """Cherry-pick the commit <ref> onto <branch>."""
+    def cherrypick(self, ref: str) -> None:
+        """Cherry-pick the commit <ref>."""
         commit = self.repo.revparse_single(ref)
-        head = self.repo.branches[branch] if branch is not None else self.repo.head
+        head = self.repo.head
         index = self.repo.merge_trees(commit.parents[0].tree, head, commit)
         tree = index.write_tree(self.repo)
         committer = self.repo.default_signature

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ def commit(repository: git.Repository, message: str = "") -> str:
     return cast(str, repository.repo.head.target.hex)
 
 
-def write(repository: git.Repository, path: Path, text: str) -> None:
+def write(repository: git.Repository, path: Path, text: str) -> str:
     """Write file in repository."""
     path = repository.path / path
     path.write_text(text)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@
 import contextlib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 from typing import Iterator
 
 from retrocookie import git
@@ -12,17 +13,18 @@ def read(repository: git.Repository, path: Path) -> str:
     return repository.read_text(path)
 
 
-def commit(repository: git.Repository, path: Path) -> None:
-    """Create a commit with the path."""
-    repository.add(path)
-    repository.commit(f"Update {path.name}")
+def commit(repository: git.Repository, message: str = "") -> str:
+    """Create a commit and return the hash."""
+    repository.commit(message)
+    return cast(str, repository.repo.head.target.hex)
 
 
 def write(repository: git.Repository, path: Path, text: str) -> None:
     """Write file in repository."""
     path = repository.path / path
     path.write_text(text)
-    commit(repository, path)
+    repository.add(path)
+    return commit(repository, f"Update {path.name}")
 
 
 def append(repository: git.Repository, path: Path, text: str) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -5,6 +5,7 @@ import pytest
 
 from .helpers import branch
 from .helpers import commit
+from .helpers import write
 from retrocookie import git
 
 
@@ -61,6 +62,20 @@ def test_cherrypick(repository: git.Repository) -> None:
 
     assert ignore_text == repository.read_text(ignore)
     assert message in repository.read_text(readme)
+
+
+def test_cherrypick_index(repository: git.Repository) -> None:
+    """It updates the index from the cherry-pick."""
+    readme, install = map(Path, ("README", "INSTALL"))
+
+    write(repository, readme, "")
+
+    with branch(repository, "install", create=True):
+        write(repository, install, "")
+
+    repository.cherrypick("install")
+
+    assert "INSTALL" in {e.path for e in repository.repo.index}
 
 
 def test_parse_revisions(repository: git.Repository) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,10 +1,10 @@
 """Tests for git interface."""
 from pathlib import Path
-from typing import cast
 
 import pytest
 
 from .helpers import branch
+from .helpers import commit
 from retrocookie import git
 
 
@@ -61,12 +61,6 @@ def test_cherrypick(repository: git.Repository) -> None:
 
     assert ignore_text == repository.read_text(ignore)
     assert message in repository.read_text(readme)
-
-
-def commit(repository: git.Repository) -> str:
-    """Create an empty commit and return the hash."""
-    repository.commit("")
-    return cast(str, repository.repo.head.target.hex)
 
 
 def test_parse_revisions(repository: git.Repository) -> None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -78,6 +78,21 @@ def test_cherrypick_index(repository: git.Repository) -> None:
     assert "INSTALL" in {e.path for e in repository.repo.index}
 
 
+def test_cherrypick_conflict(repository: git.Repository) -> None:
+    """It raises an exception if the cherry-pick results in conflicts."""
+    path = Path("README")
+
+    write(repository, path, "")
+
+    with branch(repository, "topic", create=True):
+        write(repository, path, "a")
+
+    write(repository, path, "b")
+
+    with pytest.raises(git.Conflict):
+        repository.cherrypick("topic")
+
+
 def test_parse_revisions(repository: git.Repository) -> None:
     """It returns the hashes on topic for the range expression ``..topic``."""
     commit(repository)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -78,6 +78,20 @@ def test_cherrypick_index(repository: git.Repository) -> None:
     assert "INSTALL" in {e.path for e in repository.repo.index}
 
 
+def test_cherrypick_worktree(repository: git.Repository) -> None:
+    """It updates the worktree from the cherry-pick."""
+    readme, install = map(Path, ("README", "INSTALL"))
+
+    write(repository, readme, "")
+
+    with branch(repository, "install", create=True):
+        write(repository, install, "")
+
+    repository.cherrypick("install")
+
+    assert (repository.path / install).exists()
+
+
 def test_cherrypick_conflict(repository: git.Repository) -> None:
     """It raises an exception if the cherry-pick results in conflicts."""
     path = Path("README")


### PR DESCRIPTION
Replace the in-memory cherry picking implementation by one based on `pygit2.Repository.cherrypick`:

- Update the index and worktree to reflect the cherry picked commit.
- Record cherry picking state to allow conflict resolution or abortion using git-cherry-pick.
- Handle conflicts by raising a `git.Conflict` exception with the conflicts.

Note that the `git.Conflict` exception leaks implementation details, because the exception argument is a `pygit2.index.ConflictCollection`.