### PR TITLE
Minor cleanup in git-filter-repo interface

### DIFF
--- a/src/retrocookie/filter.py
+++ b/src/retrocookie/filter.py
@@ -111,7 +111,7 @@ class RepositoryFilter:
 
     def _create_filter(self) -> RepoFilter:
         """Create the filter."""
-        args = FilteringOptions.parse_args([], error_on_empty=False)
+        args = FilteringOptions.default_options()
         return RepoFilter(
             args,
             filename_callback=self.filename_callback,


### PR DESCRIPTION
Simplify `RepositoryFilter._create_filter` using `git_filter_repo.FilteringOptions.default_options`.