### PR TITLE
Refactor retrocookie

### DIFF
--- a/src/retrocookie/__main__.py
+++ b/src/retrocookie/__main__.py
@@ -113,7 +113,7 @@ def main(
     path = Path(directory) if directory else None
     retrocookie(
         Path(repository),
-        commits=commits,
+        commits,
         branch=branch,
         upstream=upstream,
         create_branch=create_branch,

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -134,11 +134,11 @@ def retrocookie(
     template_directory = find_template_directory(repository)
     commits = get_commits(instance_, commits, branch, upstream)
 
-    with temporary_repository(instance_path) as instance:
+    with temporary_repository(instance_path) as scratch:
         commits = rewrite_commits(
-            instance, template_directory, whitelist, blacklist, commits
+            scratch, template_directory, whitelist, blacklist, commits
         )
 
         remote = "retrocookie"
-        with temporary_remote(repository, remote, str(instance.path)):
+        with temporary_remote(repository, remote, str(scratch.path)):
             apply_commits(repository, remote, commits, create_branch)

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -87,8 +87,8 @@ def apply_commits(
 
 def retrocookie(
     instance_path: Path,
-    *,
     commits: Iterable[str] = (),
+    *,
     branch: Optional[str] = None,
     upstream: str = "master",
     create_branch: Optional[str] = None,

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -89,12 +89,12 @@ def retrocookie(
     instance_path: Path,
     commits: Iterable[str] = (),
     *,
+    path: Optional[Path] = None,
     branch: Optional[str] = None,
     upstream: str = "master",
     create_branch: Optional[str] = None,
     whitelist: Container[str] = (),
     blacklist: Container[str] = (),
-    path: Optional[Path] = None,
 ) -> None:
     """Import commits from instance repository into template repository."""
     repository = git.Repository(path)

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -130,11 +130,11 @@ def retrocookie(
 
     """
     repository = git.Repository(path)
-    instance_ = git.Repository(instance_path)
+    instance = git.Repository(instance_path)
     template_directory = find_template_directory(repository)
-    commits = get_commits(instance_, commits, branch, upstream)
+    commits = get_commits(instance, commits, branch, upstream)
 
-    with temporary_repository(instance_path) as scratch:
+    with temporary_repository(instance.path) as scratch:
         commits = rewrite_commits(
             scratch, template_directory, whitelist, blacklist, commits
         )

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -131,7 +131,6 @@ def retrocookie(
     """
     repository = git.Repository(path)
     template_directory = find_template_directory(repository)
-    remote = "retrocookie"
 
     with temporary_repository(instance_path) as instance:
         commits = get_commits(instance, commits, branch, upstream)
@@ -139,5 +138,6 @@ def retrocookie(
             instance, template_directory, whitelist, blacklist, commits
         )
 
+        remote = "retrocookie"
         with temporary_remote(repository, remote, str(instance.path)):
             apply_commits(repository, remote, commits, create_branch)

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -95,8 +95,40 @@ def retrocookie(
     create_branch: Optional[str] = None,
     whitelist: Container[str] = (),
     blacklist: Container[str] = (),
-) -> None:
-    """Import commits from instance repository into template repository."""
+) -> None:  # noqa: DAR101
+    """Import commits from instance repository into template repository.
+
+    This function imports a commits from an instance of the Cookiecutter
+    template, rewriting occurrences of template variables back into the
+    original templating tags, and prepending the template directory to
+    filenames. Any tokens with special meaning in Jinja are escaped.
+
+    Args:
+        instance_path: The source repository, an instance of the Cookiecutter
+            template with a ``.cookiecutter.json`` file.
+
+        commits: The commits to be imported from the source repository.
+
+        path: The target repository, a Cookiecutter template. This defaults to
+            the current working directory.
+
+        branch: The name of a branch to be imported from the source repository.
+            This is equivalent to passing ``["master..branch"]`` in the
+            ``commits`` parameter.
+
+        upstream: The upstream for ``branch``, by default the master branch.
+
+        create_branch: The name of the branch to be created in the target
+            repository. By default, commits are imported onto the current
+            branch.
+
+        whitelist: The Cookiecutter variables which should be rewritten. If
+            this is not specified, all variables from cookiecutter.json are
+            rewritten.
+
+        blacklist: Any Cookiecutter variables which should not be rewritten.
+
+    """
     repository = git.Repository(path)
     template_directory = find_template_directory(repository)
     remote = "retrocookie"

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -130,10 +130,11 @@ def retrocookie(
 
     """
     repository = git.Repository(path)
+    instance_ = git.Repository(instance_path)
     template_directory = find_template_directory(repository)
+    commits = get_commits(instance_, commits, branch, upstream)
 
     with temporary_repository(instance_path) as instance:
-        commits = get_commits(instance, commits, branch, upstream)
         commits = rewrite_commits(
             instance, template_directory, whitelist, blacklist, commits
         )

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -95,7 +95,7 @@ def retrocookie(
     create_branch: Optional[str] = None,
     whitelist: Container[str] = (),
     blacklist: Container[str] = (),
-) -> None:  # noqa: DAR101
+) -> None:  # noqa: DAR101 https://github.com/terrencepreilly/darglint/issues/56
     """Import commits from instance repository into template repository.
 
     This function imports a commits from an instance of the Cookiecutter

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -79,7 +79,7 @@ def test_commits(
     change = Append(Path("README.md"), "Lorem Ipsum\n")
     apply(instance, change)
 
-    retrocookie(instance.path, commits=["HEAD"], path=cookiecutter.path)
+    retrocookie(instance.path, ["HEAD"], path=cookiecutter.path)
 
     assert change.text in read(cookiecutter, in_template(change.path))
 


### PR DESCRIPTION
- Resolve commits before cloning the instance repository
- Do not require `commits` to be passed by keyword
- Add docstring
- Clean up local variables