### PR TITLE
Fix missing commits when fetching from multiple branches

### DIFF
--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -65,9 +65,13 @@ def rewrite_commits(
 ) -> List[str]:
     """Rewrite the repository using template variables."""
     commits = list(commits)
+    with_parents = repository.parse_revisions(
+        *[f"{commit}^" for commit in commits], *commits
+    )
     context = load_context(repository, commits[-1])
     RepositoryFilter(
         repository=repository,
+        commits=with_parents,
         template_directory=template_directory,
         context=context,
         whitelist=whitelist,

--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -68,7 +68,7 @@ def rewrite_commits(
     context = load_context(repository, commits[-1])
     RepositoryFilter(
         repository=repository,
-        path=template_directory,
+        template_directory=template_directory,
         context=context,
         whitelist=whitelist,
         blacklist=blacklist,

--- a/src/retrocookie/filter.py
+++ b/src/retrocookie/filter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 from typing import Container
 from typing import Dict
+from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import overload
@@ -87,6 +88,7 @@ class RepositoryFilter:
     def __init__(
         self,
         repository: git.Repository,
+        commits: Iterable[str],
         template_directory: Path,
         context: Dict[str, str],
         whitelist: Container[str],
@@ -94,6 +96,7 @@ class RepositoryFilter:
     ) -> None:
         """Initialize."""
         self.repository = repository
+        self.commits = commits
         self.template_directory = str(template_directory).encode()
         self.replacements = get_replacements(context, whitelist, blacklist)
 
@@ -111,7 +114,9 @@ class RepositoryFilter:
 
     def _create_filter(self) -> RepoFilter:
         """Create the filter."""
-        args = FilteringOptions.parse_args(["--force"])
+        args = FilteringOptions.parse_args(
+            ["--force", "--replace-refs=update-and-add", "--refs", *self.commits]
+        )
         return RepoFilter(
             args,
             filename_callback=self.filename_callback,

--- a/src/retrocookie/filter.py
+++ b/src/retrocookie/filter.py
@@ -87,21 +87,21 @@ class RepositoryFilter:
     def __init__(
         self,
         repository: git.Repository,
-        path: Path,
+        template_directory: Path,
         context: Dict[str, str],
         whitelist: Container[str],
         blacklist: Container[str],
     ) -> None:
         """Initialize."""
         self.repository = repository
-        self.path = str(path).encode()
+        self.template_directory = str(template_directory).encode()
         self.replacements = get_replacements(context, whitelist, blacklist)
 
     def filename_callback(self, filename: bytes) -> bytes:
         """Rewrite filenames."""
         for old, new in self.replacements:
             filename = filename.replace(old, new)
-        return b"/".join((self.path, filename))
+        return b"/".join((self.template_directory, filename))
 
     def blob_callback(self, blob: Blob, metadata: Dict[str, Any]) -> None:
         """Rewrite blobs."""

--- a/src/retrocookie/git.py
+++ b/src/retrocookie/git.py
@@ -97,6 +97,16 @@ class Repository:
         blob = functools.reduce(operator.truediv, path.parts, commit.tree)
         return cast(str, blob.data.decode())
 
+    def exists(self, path: Path, *, ref: str = "HEAD") -> bool:
+        """Return True if a blob exists at the given path."""
+        commit = self.repo.revparse_single(ref)
+        path = self._ensure_relative(path)
+        try:
+            functools.reduce(operator.truediv, path.parts, commit.tree)
+            return True
+        except KeyError:
+            return False
+
     def add(self, *paths: Path) -> None:
         """Add paths to the index."""
         for path in paths:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -103,6 +103,25 @@ def test_multiple_commits_sequential(
         assert cookiecutter.exists(path)
 
 
+def test_multiple_commits_parallel(
+    cookiecutter_repository: git.Repository,
+    cookiecutter_instance_repository: git.Repository,
+) -> None:
+    """It cherry-picks the specified commits."""
+    cookiecutter, instance = cookiecutter_repository, cookiecutter_instance_repository
+    names = "first", "second"
+
+    for name in names:
+        with branch(instance, name, create=True):
+            touch(instance, Path(name))
+
+    retrocookie(instance.path, names, path=cookiecutter.path)
+
+    for name in names:
+        path = in_template(Path(name))
+        assert cookiecutter.exists(path)
+
+
 def test_find_template_directory_fails(tmp_path: Path) -> None:
     """It raises an exception when there is no template directory."""
     repository = git.Repository.init(tmp_path)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import pytest
 from .helpers import append
 from .helpers import branch
 from .helpers import in_template
+from .helpers import touch
 from retrocookie import core
 from retrocookie import git
 from retrocookie import retrocookie
@@ -82,6 +83,24 @@ def test_single_commit(
     retrocookie(instance.path, ["HEAD"], path=cookiecutter.path)
 
     assert text in cookiecutter.read_text(in_template(path))
+
+
+def test_multiple_commits_sequential(
+    cookiecutter_repository: git.Repository,
+    cookiecutter_instance_repository: git.Repository,
+) -> None:
+    """It cherry-picks the specified commits."""
+    cookiecutter, instance = cookiecutter_repository, cookiecutter_instance_repository
+    names = "first", "second"
+
+    for name in names:
+        touch(instance, Path(name))
+
+    retrocookie(instance.path, ["HEAD~2.."], path=cookiecutter.path)
+
+    for name in names:
+        path = in_template(Path(name))
+        assert cookiecutter.exists(path)
 
 
 def test_find_template_directory_fails(tmp_path: Path) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,11 +69,11 @@ def test_branch(
         assert text in cookiecutter.read_text(in_template(path))
 
 
-def test_commits(
+def test_single_commit(
     cookiecutter_repository: git.Repository,
     cookiecutter_instance_repository: git.Repository,
 ) -> None:
-    """It cherry-picks the specified commits."""
+    """It cherry-picks the specified commit."""
     cookiecutter, instance = cookiecutter_repository, cookiecutter_instance_repository
     path = Path("README.md")
     text = "Lorem Ipsum\n"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -33,6 +33,22 @@ def test_read_text(repository: git.Repository) -> None:
     assert path.read_text() == repository.read_text(path)
 
 
+def test_exists_true(repository: git.Repository) -> None:
+    """It returns True if the file exists."""
+    path = Path("README.md")
+    touch(repository, path)
+
+    assert repository.exists(path)
+
+
+def test_exists_false(repository: git.Repository) -> None:
+    """It returns False if the file does not exist."""
+    path = Path("README.md")
+    commit(repository)  # ensure HEAD exists
+
+    assert not repository.exists(path)
+
+
 def test_cherrypick(repository: git.Repository) -> None:
     """It applies a commit from another branch."""
     # Add README on master.


### PR DESCRIPTION
When fetching commits from multiple branches, `git fast-export` did not include all of them in its output. This resulted in a failure directly after rewrite, when looking up the new commit hashes in the replacement refs.

Fix this by passing the commits and their immediate parents to git-filter-repo, using the `--refs` option. This implies `--partial`, and therefore requires explicitly enabling `--replace-refs=update-and-add`, which is no longer the default with partial rewrites.