### PR TITLE
Fix unescaped token when another token is present

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -11,6 +11,7 @@ from retrocookie.filter import escape_jinja
         ("{{}}", '{{ "{{" }}{{ "}}" }}'),
         ("${{ matrix.os }}", '${{ "{{" }} matrix.os {{ "}}" }}'),
         ("lorem {# ipsum #} dolor", 'lorem {{ "{#" }} ipsum {{ "#}" }} dolor'),
+        ("{{ a }} {{ b }}", '{{ "{{" }} a {{ "}}" }} {{ "{{" }} b {{ "}}" }}'),
     ],
 )
 def test_escape_jinja(text: str, expected: str) -> None:


### PR DESCRIPTION
When looking for multiple tokens, `quote_tokens` preferred tokens listed earlier in `tokens`, even when they occur later in the text. Instead, always return the first occurrence of any of the listed tokens.