### PR TITLE
Enable runtime type-checking with Typeguard by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
             ${{ steps.pre-commit-cache.outputs.result }}-
 
       - name: Configure git
-        if: matrix.session == 'tests'
+        if: matrix.session == 'tests' || matrix.session == 'typeguard'
         run: |
           git config --global user.name "GitHub Action"
           git config --global user.email "action@github.com"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - { python-version: 3.7, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.8, os: windows-latest, session: "tests" }
           - { python-version: 3.8, os: macos-latest, session: "tests" }
+          - { python-version: 3.8, os: ubuntu-latest, session: "typeguard" }
           - { python-version: 3.8, os: ubuntu-latest, session: "docs" }
 
     env:

--- a/noxfile.py
+++ b/noxfile.py
@@ -162,7 +162,7 @@ def coverage(session: Session) -> None:
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     install_package(session)
-    install(session, "pytest", "typeguard")
+    install(session, "cookiecutter", "pytest", "typeguard")
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ from nox.sessions import Session
 
 package = "retrocookie"
 python_versions = ["3.8", "3.7"]
-nox.options.sessions = "pre-commit", "safety", "mypy", "tests"
+nox.options.sessions = "pre-commit", "safety", "mypy", "tests", "typeguard"
 locations = "src", "tests", "noxfile.py", "docs/conf.py"
 
 


### PR DESCRIPTION
- Add typeguard session to the default Nox sessions
- Add typeguard session to the Tests workflow
- Fix a missing dependency in the Nox session for Typeguard