### PR TITLE
Use git-cherry-pick instead of pygit2

### DIFF
--- a/src/retrocookie/core.py
+++ b/src/retrocookie/core.py
@@ -91,8 +91,7 @@ def apply_commits(
         repository.create_branch(create_branch)
         repository.switch_branch(create_branch)
 
-    for commit in commits:
-        repository.cherrypick(commit)
+    repository.cherrypick(*commits)
 
 
 def retrocookie(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,5 +1,5 @@
 """Tests for git interface."""
-import subprocess
+import subprocess  # noqa: S404
 from pathlib import Path
 from typing import Dict
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,4 +1,5 @@
 """Tests for git interface."""
+import subprocess
 from pathlib import Path
 from typing import Dict
 
@@ -112,6 +113,7 @@ def test_cherrypick_index(repository: git.Repository) -> None:
 
     repository.cherrypick("install")
 
+    repository.repo.index.read()  # refresh stale index
     assert "INSTALL" in {e.path for e in repository.repo.index}
 
 
@@ -140,7 +142,7 @@ def test_cherrypick_conflict(repository: git.Repository) -> None:
 
     write(repository, path, "b")
 
-    with pytest.raises(git.Conflict):
+    with pytest.raises(subprocess.CalledProcessError):
         repository.cherrypick("topic")
 
 


### PR DESCRIPTION
Our simplistic implementation using pygit2 suffers from several shortcomings:

- We are only handling one commit at a time, so sequencing (abort, continue, skip) does not work properly: Abort does not rewind the previously applied commits, continue does not apply more than the current commit, and skip simply fails.

- The commit message includes the list of conflicting files.

There is another shortcoming that is not fixed by this change: When the user aborts a cherry-pick in progress, a previously created branch is not deleted. The correct behavior in this case also requires some more thought. (Maybe we should simply refrain from creating branches for the user?)

Closes #95 
Closes #94 

See also #93 