### PR TITLE
Do not import MonkeyPatch from internal _pytest package

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 from .helpers import branch
 from .helpers import commit

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Iterable
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from click.testing import CliRunner
+from pytest import MonkeyPatch
 
 from .helpers import append
 from .helpers import branch


### PR DESCRIPTION
As of pytest 6.2, the type is part of the public interface.
