### PR TITLE
Clean up prompts in doctests     

### DIFF
--- a/src/retrocookie/pr/base/bus.py
+++ b/src/retrocookie/pr/base/bus.py
@@ -10,11 +10,11 @@ to determine which handlers to invoke when an event is published.
 >>> class Timber(Event):
 ...     pass
 ...
-... def shout(event: Timber):
+>>> def shout(event: Timber):
 ...     print("Timber!")
 ...
-... bus = Bus()
-... bus.events.subscribe(shout)
+>>> bus = Bus()
+>>> bus.events.subscribe(shout)
 >>> bus.events.publish(Timber())
 Timber!
 
@@ -38,9 +38,9 @@ context.
 >>> class Copy(Context):
 ...     pass
 ...
-... import contextlib
+>>> import contextlib
 ...
-... @contextlib.contextmanager
+>>> @contextlib.contextmanager
 ... def handle_copy(context: Copy):
 ...     print("starting copy...")
 ...     try:
@@ -51,7 +51,7 @@ context.
 ...     else:
 ...         print("copy complete.")
 ...
-... bus.contexts.subscribe(handle_copy)
+>>> bus.contexts.subscribe(handle_copy)
 >>> with bus.contexts.publish(Copy()):
 ...     print("copy: file a")
 ...     print("copy: file b")

--- a/src/retrocookie/pr/base/exceptionhandlers.py
+++ b/src/retrocookie/pr/base/exceptionhandlers.py
@@ -8,7 +8,7 @@ Consider the following imaginary application:
 >>> class ApplicationError(Exception):
 ...     pass
 ...
-... def main():
+>>> def main():
 ...     pass
 
 Conventionally, application errors would be handled using a ``try...except``


### PR DESCRIPTION
The primary prompt `>>> ` must be used for each separate statement in a doctest containing multiple statements. Continuations may be preceded by the secondary prompt `... `---this is mandatory in the doctest module, and optional in xdoctest which allows `>>> ` throughout.

A doctest with a single `>>> ` prompt followed by only `... ` uses the [compile] builtin in single mode, and a `SyntaxError: invalid syntax` is raised if there are multiple statements. This is the behavior of both doctest and xdoctest.

See https://github.com/Erotemic/xdoctest/issues/93

[compile]: https://docs.python.org/3/library/functions.html#compile