### PR TITLE
👷 [github] Relax concurrency limits between runs, users, and events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,31 +17,31 @@ jobs:
               python-version: 3.9,
               os: ubuntu-latest,
               session: "pre-commit",
-              concurrency: "${{ github.run_attempt }}-1",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-1",
             }
           - {
               python-version: 3.9,
               os: ubuntu-latest,
               session: "safety",
-              concurrency: "${{ github.run_attempt }}-2",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-2",
             }
           - {
               python-version: 3.9,
               os: ubuntu-latest,
               session: "mypy",
-              concurrency: "${{ github.run_attempt }}-3",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-3",
             }
           - {
               python-version: 3.8,
               os: ubuntu-latest,
               session: "mypy",
-              concurrency: "${{ github.run_attempt }}-4",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-4",
             }
           - {
               python-version: 3.7,
               os: ubuntu-latest,
               session: "mypy",
-              concurrency: "${{ github.run_attempt }}-5",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-5",
             }
           - {
               python-version: 3.9,
@@ -53,13 +53,13 @@ jobs:
               python-version: 3.8,
               os: ubuntu-latest,
               session: "tests",
-              concurrency: "${{ github.run_attempt }}-6",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-6",
             }
           - {
               python-version: 3.7,
               os: ubuntu-latest,
               session: "tests",
-              concurrency: "${{ github.run_attempt }}-7",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-7",
             }
           - {
               python-version: 3.9,
@@ -71,25 +71,25 @@ jobs:
               python-version: 3.9,
               os: macos-latest,
               session: "tests",
-              concurrency: "${{ github.run_attempt }}-8",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-8",
             }
           - {
               python-version: 3.9,
               os: ubuntu-latest,
               session: "typeguard",
-              concurrency: "${{ github.run_attempt }}-9",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-9",
             }
           - {
               python-version: 3.9,
               os: ubuntu-latest,
               session: "xdoctest",
-              concurrency: "${{ github.run_attempt }}-10",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-10",
             }
           - {
               python-version: 3.8,
               os: ubuntu-latest,
               session: "docs-build",
-              concurrency: "${{ github.run_attempt }}-11",
+              concurrency: "${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-11",
             }
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
               python-version: 3.9,
               os: ubuntu-latest,
               session: "tests",
-              concurrency: ubuntu,
+              concurrency: "${{ github.actor }}-ubuntu",
             }
           - {
               python-version: 3.8,
@@ -65,7 +65,7 @@ jobs:
               python-version: 3.9,
               os: windows-latest,
               session: "tests",
-              concurrency: windows,
+              concurrency: "${{ github.actor }}-windows",
             }
           - {
               python-version: 3.9,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
               python-version: 3.9,
               os: ubuntu-latest,
               session: "tests",
-              concurrency: "${{ github.actor }}-ubuntu",
+              concurrency: "${{ github.actor }}-${{ github.event_name }}-ubuntu",
             }
           - {
               python-version: 3.8,
@@ -65,7 +65,7 @@ jobs:
               python-version: 3.9,
               os: windows-latest,
               session: "tests",
-              concurrency: "${{ github.actor }}-windows",
+              concurrency: "${{ github.actor }}-${{ github.event_name }}-windows",
             }
           - {
               python-version: 3.9,

--- a/tests/pr/functional/conftest.py
+++ b/tests/pr/functional/conftest.py
@@ -2,6 +2,7 @@
 import json
 import os
 import secrets
+import time
 from pathlib import Path
 from typing import Callable
 from typing import Iterator
@@ -119,6 +120,12 @@ def create_project_pull_request(project: Repository, branch: str) -> CreatePullR
     """Return a pull request for the template project."""
 
     def _create(path: Path, content: str) -> PullRequest:
+        # Wait four seconds before creating each pull request. GitHub requests one
+        # second between each request for a single user, but we run these tests
+        # concurrently for two platforms and two event types (pull_request and push).
+        # See https://docs.github.com/en/rest/guides/best-practices-for-integrators
+        time.sleep(4)
+
         project_default_branch = project.branch(project.default_branch)
         project.create_ref(f"refs/heads/{branch}", project_default_branch.commit.sha)
 


### PR DESCRIPTION
- Checks that don't run functional tests should not have limited concurrency at all. It seems there is no direct way to express this as a value of `concurrency`. (I tried `null` which led to an error.) Instead, we use all of run ID, run number, and run attempt, plus an integer identifying the matrix entry. Previously, we only had run attempt and the matrix entry, but run attempt is relative to the workflow run, so this gave us something like `1-1`.
- Functional tests should be allowed to run concurrently between PR runs (`pull_request` events) and commit runs (`push` events). Otherwise, pending jobs will be cancelled. There is currently no way to switch the cancellation off for pending jobs, only for jobs in progress. See https://github.com/github/feedback/discussions/5435
- We also allow each user to run functional tests even if another user is already running them. This means that Dependabot cannot block the CI when we need to make some non-automated PRs.
- Wait four seconds before creating each pull request. GitHub requests one second between each request for a single user, but we run these tests concurrently for two platforms and two event types (`pull_request` and `push`). See https://docs.github.com/en/rest/guides/best-practices-for-integrators