### PR TITLE
👷 [nox] Avoid mypy warning about unreachable code

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,8 +32,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
     Args:
         session: The Session object.
     """
-    if session.bin is None:
-        return
+    assert session.bin is not None  # noqa: S101
 
     virtualenv = session.env.get("VIRTUAL_ENV")
     if virtualenv is None:


### PR DESCRIPTION
`nox.Session.bin` is no longer `Optional` in recent versions of Nox.

See https://github.com/cjolowicz/cookiecutter-hypermodern-python#1025
