### PR TITLE
📚 Use furo Sphinx theme for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_click",
-    "sphinx_rtd_theme",
 ]
 autodoc_typehints = "description"
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,9 +1,8 @@
 Reference
 =========
 
-.. contents::
-    :local:
-    :backlinks: none
 
+retrocookie
+-----------
 
 .. autofunction:: retrocookie.retrocookie

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
+furo==2021.11.12
 sphinx==4.3.0
 sphinx-click==3.0.2
-sphinx-rtd-theme==1.0.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,7 +181,7 @@ def docs_build(session: Session) -> None:
         args.insert(0, "--color")
 
     session.install(".[pr]")
-    session.install("sphinx", "sphinx-click", "sphinx-rtd-theme")
+    session.install("sphinx", "sphinx-click", "furo")
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():
@@ -195,7 +195,7 @@ def docs(session: Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]
     session.install(".[pr]")
-    session.install("sphinx", "sphinx-autobuild", "sphinx-click", "sphinx-rtd-theme")
+    session.install("sphinx", "sphinx-autobuild", "sphinx-click", "furo")
 
     build_dir = Path("docs", "_build")
     if build_dir.exists():

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,6 +85,21 @@ six = ">=1.10.0"
 stevedore = ">=1.20.0"
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.10.0"
+description = "Screen-scraping library"
+category = "dev"
+optional = false
+python-versions = ">3.0.0"
+
+[package.dependencies]
+soupsieve = ">1.2"
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "binaryornot"
 version = "0.4.4"
 description = "Ultra-lightweight pure Python package to check if a file is binary or text."
@@ -382,6 +397,22 @@ python-versions = ">=3.3"
 flake8 = ">=3.0.0"
 pygments = "*"
 restructuredtext-lint = "*"
+
+[[package]]
+name = "furo"
+version = "2021.11.16"
+description = "A clean customisable Sphinx documentation theme."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+beautifulsoup4 = "*"
+sphinx = ">=4.0,<5.0"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-xdist"]
+doc = ["myst-parser", "sphinx-copybutton", "sphinx-design", "sphinx-inline-tabs"]
 
 [[package]]
 name = "git-filter-repo"
@@ -937,6 +968,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "soupsieve"
+version = "2.3.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "sphinx"
 version = "4.3.0"
 description = "Python documentation generator"
@@ -994,20 +1033,6 @@ python-versions = ">=3.6"
 click = ">=7.0"
 docutils = "*"
 sphinx = ">=2.0"
-
-[[package]]
-name = "sphinx-rtd-theme"
-version = "0.5.1"
-description = "Read the Docs theme for Sphinx"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -1243,7 +1268,7 @@ pr = ["appdirs", "github3.py", "rich", "tenacity", "typing-extensions"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "90e7d8037691393ac38b065848b778094e747e37ccc6d93f1acfcde402fd0b2c"
+content-hash = "8eddf2be8e0b07819929ad73e89468f1936220a1febf5436c9fbe4922de8d5ab"
 
 [metadata.files]
 alabaster = [
@@ -1277,6 +1302,10 @@ babel = [
 bandit = [
     {file = "bandit-1.6.2-py2.py3-none-any.whl", hash = "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952"},
     {file = "bandit-1.6.2.tar.gz", hash = "sha256:41e75315853507aa145d62a78a2a6c5e3240fe14ee7c601459d0df9418196065"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.10.0-py3-none-any.whl", hash = "sha256:9a315ce70049920ea4572a4055bc4bd700c940521d36fc858205ad4fcde149bf"},
+    {file = "beautifulsoup4-4.10.0.tar.gz", hash = "sha256:c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891"},
 ]
 binaryornot = [
     {file = "binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4"},
@@ -1465,6 +1494,10 @@ flake8-polyfill = [
 flake8-rst-docstrings = [
     {file = "flake8-rst-docstrings-0.2.3.tar.gz", hash = "sha256:3045794e1c8467fba33aaea5c246b8369efc9c44ef8b0b20199bb6df7a4bd47b"},
     {file = "flake8_rst_docstrings-0.2.3-py3-none-any.whl", hash = "sha256:565bbb391d7e4d0042924102221e9857ad72929cdd305b26501736ec22c1451a"},
+]
+furo = [
+    {file = "furo-2021.11.16-py3-none-any.whl", hash = "sha256:9bbdf203e84e048391b58a3bc2d4baf13f462604661553cf72e22eae61db116a"},
+    {file = "furo-2021.11.16.tar.gz", hash = "sha256:bb1d1a088cd09d4e9aaac908230f819ebdc94baa007d0561a2034b37dcb8ea6c"},
 ]
 git-filter-repo = [
     {file = "git-filter-repo-2.34.0.tar.gz", hash = "sha256:b5a09f383865de0a164b06ba174461e55d9167cc6fbb06cf2a1e62dbf0cdba63"},
@@ -1846,6 +1879,10 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
+soupsieve = [
+    {file = "soupsieve-2.3.1-py3-none-any.whl", hash = "sha256:1a3cca2617c6b38c0343ed661b1fa5de5637f257d4fe22bd9f1338010a1efefb"},
+    {file = "soupsieve-2.3.1.tar.gz", hash = "sha256:b8d49b1cd4f037c7082a9683dfa1801aa2597fb11c3a1155b7a5b94829b4f1f9"},
+]
 sphinx = [
     {file = "Sphinx-4.3.0-py3-none-any.whl", hash = "sha256:7e2b30da5f39170efcd95c6270f07669d623c276521fee27ad6c380f49d2bf5b"},
     {file = "Sphinx-4.3.0.tar.gz", hash = "sha256:6d051ab6e0d06cba786c4656b0fe67ba259fe058410f49e95bee6e49c4052cbf"},
@@ -1857,10 +1894,6 @@ sphinx-autobuild = [
 sphinx-click = [
     {file = "sphinx-click-3.0.2.tar.gz", hash = "sha256:29896dd12bfaacb566a8c7af2e2b675d010d69b0c5aad3b52495d4842358b15b"},
     {file = "sphinx_click-3.0.2-py3-none-any.whl", hash = "sha256:8529a02bea8cd2cd47daba2f71d7935c727c89d70baabec7fca31af49a0c379f"},
-]
-sphinx-rtd-theme = [
-    {file = "sphinx_rtd_theme-0.5.1-py2.py3-none-any.whl", hash = "sha256:fa6bebd5ab9a73da8e102509a86f3fcc36dec04a0b52ea80e5a033b2aba00113"},
-    {file = "sphinx_rtd_theme-0.5.1.tar.gz", hash = "sha256:eda689eda0c7301a80cf122dad28b1861e5605cbf455558f3775e1e8200e83a5"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ pep8-naming = "^0.11.1"
 darglint = "^1.5.8"
 reorder-python-imports = "^2.3.6"
 pre-commit-hooks = "^3.4.0"
-sphinx-rtd-theme = "^0.5.1"
 sphinx-click = "^3.0.2"
 Pygments = "^2.10.0"
+furo = ">=2021.11.12"
 
 [tool.poetry.extras]
 pr = ["appdirs", "github3.py", "rich", "tenacity", "typing-extensions"]


### PR DESCRIPTION
* ➕ [poetry] Add furo >=2021.11.12 to development dependencies

* 👷 [nox] Install furo in docs and docs-build sessions

* ➕ [docs] Add furo==2021.11.12 to requirements

* 🔧 [docs] Use furo Sphinx theme

* 📚 [docs] Remove table of contents from API Reference

The table of contents duplicates furo's right sidebar.

* 📚 [docs] Generate API documentation for package not `__main__`

`reference.rst` inserts the API documentation for the `__main__` module. That
makes little sense, as it only contains the Click entry point, whose docstring
is not intended for consumption by Sphinx.

Instead, insert API documentation for the package. This generates documentation
for anything in `__init__`. On project generation, this is only be the package
docstring, which is fine.

* ➖ [docs] Remove sphinx-rtd-theme from requirements

* 👷 [nox] Do not install sphinx-rtd-theme in docs and docs-build sessions

* ➖ [poetry] Remove sphinx-rtd-theme from development dependencies

Retrocookie-Original-Commit: cjolowicz/cookiecutter-hypermodern-python-instance@272d565
