### PR TITLE
👷 [nox] Print full report in safety session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -109,7 +109,7 @@ def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
     session.install("safety")
-    session.run("safety", "check", f"--file={requirements}", "--bare")
+    session.run("safety", "check", "--full-report", f"--file={requirements}")
 
 
 @session(python=python_versions)


### PR DESCRIPTION
Currently, the safety session uses --bare which prints only the names of
vulnerable packages, without providing additional information, such as the
Safety DB identifier and the affected version ranges. Use --full-report instead.

See https://github.com/cjolowicz/cookiecutter-hypermodern-python#872
