### PR TITLE
:wrench: [flake8] Configure flake8-rst-docstrings for Sphinx

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,5 @@ per-file-ignores =
     src/*/__main__.py:D301
     tests/*:S101
     tests/test_git.py:S101,E241
-rst-roles = class, func
+rst-roles = class,const,func,meth,mod,ref
+rst-directives = deprecated


### PR DESCRIPTION
Configure some common Sphinx roles and directives.

See https://github.com/cjolowicz/cookiecutter-hypermodern-python#876
