### PR TITLE
🔧 [readthedocs] Use Python 3.9 when building on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,9 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.8
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - path: .
+build:
+  image: testing


### PR DESCRIPTION
See https://github.com/cjolowicz/cookiecutter-hypermodern-python#946
