### PR TITLE
👷 [github] Enable colors from pre-commit, pytest, Sphinx, and xdoctest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
 
     env:
       NOXSESSION: ${{ matrix.session }}
+      FORCE_COLOR: "1"
+      PRE_COMMIT_COLOR: "always"
 
     steps:
       - name: Check out the repository

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Nox sessions."""
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -160,16 +161,25 @@ def typeguard(session: Session) -> None:
 @session(python=python_versions)
 def xdoctest(session: Session) -> None:
     """Run examples with xdoctest."""
-    args = session.posargs or ["all"]
+    if session.posargs:
+        args = [package, *session.posargs]
+    else:
+        args = [f"--modname={package}", "--command=all"]
+        if "FORCE_COLOR" in os.environ:
+            args.append("--colored=1")
+
     session.install(".[pr]")
     session.install("xdoctest[colors]")
-    session.run("python", "-m", "xdoctest", package, *args)
+    session.run("python", "-m", "xdoctest", *args)
 
 
 @session(name="docs-build", python="3.8")
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
+    if not session.posargs and "FORCE_COLOR" in os.environ:
+        args.insert(0, "--color")
+
     session.install(".[pr]")
     session.install("sphinx", "sphinx-click", "sphinx-rtd-theme")
 


### PR DESCRIPTION
* 👷 [github] Force color output from pytest using `FORCE_COLOR`

* 👷 [github] Force color output from pre-commit using `PRE_COMMIT_COLOR`

* 👷 [nox] Force color output from Sphinx when `FORCE_COLOR` is set

* 👷 [nox] Force color output from xdoctest if `FORCE_COLOR` is set

Retrocookie-Original-Commit: https://github.com/cjolowicz/cookiecutter-hypermodern-python-instance@5348eed
