### PR TITLE
👷 Support Python 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.3.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Upgrade pip
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,39 +6,27 @@ on:
 
 jobs:
   tests:
-    name: ${{ matrix.session }} ${{ matrix.python-version }} / ${{ matrix.os }}
+    name: ${{ matrix.session }} ${{ matrix.python }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {
-              python-version: "3.10",
-              os: "ubuntu-latest",
-              session: "pre-commit",
-            }
-          - { python-version: "3.10", os: "ubuntu-latest", session: "safety" }
-          - { python-version: "3.10", os: "ubuntu-latest", session: "mypy" }
-          - { python-version: "3.9", os: "ubuntu-latest", session: "mypy" }
-          - { python-version: "3.8", os: "ubuntu-latest", session: "mypy" }
-          - { python-version: "3.7", os: "ubuntu-latest", session: "mypy" }
-          - { python-version: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python-version: "3.9", os: "ubuntu-latest", session: "tests" }
-          - { python-version: "3.8", os: "ubuntu-latest", session: "tests" }
-          - { python-version: "3.7", os: "ubuntu-latest", session: "tests" }
-          - { python-version: "3.10", os: "windows-latest", session: "tests" }
-          - { python-version: "3.10", os: "macos-latest", session: "tests" }
-          - {
-              python-version: "3.10",
-              os: "ubuntu-latest",
-              session: "typeguard",
-            }
-          - { python-version: "3.10", os: "ubuntu-latest", session: "xdoctest" }
-          - {
-              python-version: "3.10",
-              os: "ubuntu-latest",
-              session: "docs-build",
-            }
+          - { python: "3.10", os: "ubuntu-latest", session: "pre-commit" }
+          - { python: "3.10", os: "ubuntu-latest", session: "safety" }
+          - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.9", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.8", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.7", os: "ubuntu-latest", session: "mypy" }
+          - { python: "3.10", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.9", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.8", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.7", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.10", os: "windows-latest", session: "tests" }
+          - { python: "3.10", os: "macos-latest", session: "tests" }
+          - { python: "3.10", os: "ubuntu-latest", session: "typeguard" }
+          - { python: "3.10", os: "ubuntu-latest", session: "xdoctest" }
+          - { python: "3.10", os: "ubuntu-latest", session: "docs-build" }
 
     env:
       NOXSESSION: ${{ matrix.session }}
@@ -49,10 +37,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2.4.0
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2.3.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Upgrade pip
         run: |
@@ -102,7 +90,7 @@ jobs:
 
       - name: Run Nox
         run: |
-          nox --force-color --python=${{ matrix.python-version }}
+          nox --force-color --python=${{ matrix.python }}
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,19 +12,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python-version: 3.9, os: ubuntu-latest, session: "pre-commit" }
-          - { python-version: 3.9, os: ubuntu-latest, session: "safety" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "pre-commit" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "safety" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "mypy" }
           - { python-version: 3.9, os: ubuntu-latest, session: "mypy" }
           - { python-version: 3.8, os: ubuntu-latest, session: "mypy" }
           - { python-version: 3.7, os: ubuntu-latest, session: "mypy" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "tests" }
           - { python-version: 3.9, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.8, os: ubuntu-latest, session: "tests" }
           - { python-version: 3.7, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.9, os: windows-latest, session: "tests" }
-          - { python-version: 3.9, os: macos-latest, session: "tests" }
-          - { python-version: 3.9, os: ubuntu-latest, session: "typeguard" }
-          - { python-version: 3.9, os: ubuntu-latest, session: "xdoctest" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "docs-build" }
+          - { python-version: "3.10", os: windows-latest, session: "tests" }
+          - { python-version: "3.10", os: macos-latest, session: "tests" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "typeguard" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "xdoctest" }
+          - { python-version: "3.10", os: ubuntu-latest, session: "docs-build" }
 
     env:
       NOXSESSION: ${{ matrix.session }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,21 +12,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python-version: "3.10", os: ubuntu-latest, session: "pre-commit" }
-          - { python-version: "3.10", os: ubuntu-latest, session: "safety" }
-          - { python-version: "3.10", os: ubuntu-latest, session: "mypy" }
-          - { python-version: 3.9, os: ubuntu-latest, session: "mypy" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "mypy" }
-          - { python-version: 3.7, os: ubuntu-latest, session: "mypy" }
-          - { python-version: "3.10", os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.9, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.8, os: ubuntu-latest, session: "tests" }
-          - { python-version: 3.7, os: ubuntu-latest, session: "tests" }
-          - { python-version: "3.10", os: windows-latest, session: "tests" }
-          - { python-version: "3.10", os: macos-latest, session: "tests" }
-          - { python-version: "3.10", os: ubuntu-latest, session: "typeguard" }
-          - { python-version: "3.10", os: ubuntu-latest, session: "xdoctest" }
-          - { python-version: "3.10", os: ubuntu-latest, session: "docs-build" }
+          - {
+              python-version: "3.10",
+              os: "ubuntu-latest",
+              session: "pre-commit",
+            }
+          - { python-version: "3.10", os: "ubuntu-latest", session: "safety" }
+          - { python-version: "3.10", os: "ubuntu-latest", session: "mypy" }
+          - { python-version: "3.9", os: "ubuntu-latest", session: "mypy" }
+          - { python-version: "3.8", os: "ubuntu-latest", session: "mypy" }
+          - { python-version: "3.7", os: "ubuntu-latest", session: "mypy" }
+          - { python-version: "3.10", os: "ubuntu-latest", session: "tests" }
+          - { python-version: "3.9", os: "ubuntu-latest", session: "tests" }
+          - { python-version: "3.8", os: "ubuntu-latest", session: "tests" }
+          - { python-version: "3.7", os: "ubuntu-latest", session: "tests" }
+          - { python-version: "3.10", os: "windows-latest", session: "tests" }
+          - { python-version: "3.10", os: "macos-latest", session: "tests" }
+          - {
+              python-version: "3.10",
+              os: "ubuntu-latest",
+              session: "typeguard",
+            }
+          - { python-version: "3.10", os: "ubuntu-latest", session: "xdoctest" }
+          - {
+              python-version: "3.10",
+              os: "ubuntu-latest",
+              session: "docs-build",
+            }
 
     env:
       NOXSESSION: ${{ matrix.session }}
@@ -113,10 +125,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2.4.0
 
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v2.3.0
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Upgrade pip
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,12 @@
 version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
 sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 package = "retrocookie"
-python_versions = ["3.9", "3.8", "3.7"]
+python_versions = ["3.10", "3.9", "3.8", "3.7"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",
@@ -84,7 +84,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
         hook.write_text("\n".join(lines))
 
 
-@session(name="pre-commit", python="3.9")
+@session(name="pre-commit", python="3.10")
 def precommit(session: Session) -> None:
     """Lint using pre-commit."""
     args = session.posargs or ["run", "--all-files", "--show-diff-on-failure"]
@@ -107,7 +107,7 @@ def precommit(session: Session) -> None:
         activate_virtualenv_in_precommit_hooks(session)
 
 
-@session(python="3.9")
+@session(python="3.10")
 def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.poetry.export_requirements()
@@ -174,7 +174,7 @@ def xdoctest(session: Session) -> None:
     session.run("python", "-m", "xdoctest", *args)
 
 
-@session(name="docs-build", python="3.8")
+@session(name="docs-build", python="3.10")
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
@@ -191,7 +191,7 @@ def docs_build(session: Session) -> None:
     session.run("sphinx-build", *args)
 
 
-@session(python="3.8")
+@session(python="3.10")
 def docs(session: Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]


### PR DESCRIPTION
- 👷 Support Python 3.10
- 👷 [readthedocs] Use Python 3.10 on Read the Docs
- 👷 [github] Update Tests workflow to a more consistent style
- 👷 [github] Shorten `python-version` to `python` in Tests workflow matrix
