### PR TITLE
👷 Avoid merge conflicts between Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    versioning-strategy: lockfile-only

--- a/poetry.lock
+++ b/poetry.lock
@@ -1268,7 +1268,7 @@ pr = ["appdirs", "github3.py", "rich", "tenacity", "typing-extensions"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "3b6fa3a2672e71fa6e433ca16413fd4873bd3d6605f093de1a372f3c5ca0330a"
+content-hash = "070092302e218cfab5ad728c4aef23badb580f2d9d71df0eafb6dbc5b69b6c81"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,29 +32,29 @@ appdirs = {version = "^1.4.4", optional = true}
 rich = {version = ">=9.5.1,<11.0.0", optional = true}
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.2.5"
-coverage = {extras = ["toml"], version = "^6.1"}
-safety = "^1.10.3"
-mypy = "^0.800"
-typeguard = "^2.9.1"
-xdoctest = {extras = ["colors"], version = "^0.15.2"}
-sphinx = "^4.3.0"
+pytest = ">=6.2.5"
+coverage = {extras = ["toml"], version = ">=6.1"}
+safety = ">=1.10.3"
+mypy = ">=0.800"
+typeguard = ">=2.9.1"
+xdoctest = {extras = ["colors"], version = ">=0.15.2"}
+sphinx = ">=4.3.0"
 sphinx-autobuild = ">=2020.9.1"
-pre-commit = "^2.15.0"
-cookiecutter = "^1.7.3"
-pygments = "^2.10.0"
-flake8 = "^4.0.1"
+pre-commit = ">=2.15.0"
+cookiecutter = ">=1.7.3"
+pygments = ">=2.10.0"
+flake8 = ">=4.0.1"
 black = ">=21.10b0"
-flake8-bandit = "^2.1.2"
-flake8-bugbear = "^21.9.2"
-flake8-docstrings = "^1.6.0"
-flake8-rst-docstrings = "^0.2.3"
-pep8-naming = "^0.11.1"
-darglint = "^1.8.1"
-reorder-python-imports = "^2.6.0"
-pre-commit-hooks = "^4.0.1"
-sphinx-click = "^3.0.2"
-Pygments = "^2.10.0"
+flake8-bandit = ">=2.1.2"
+flake8-bugbear = ">=21.9.2"
+flake8-docstrings = ">=1.6.0"
+flake8-rst-docstrings = ">=0.2.3"
+pep8-naming = ">=0.11.1"
+darglint = ">=1.8.1"
+reorder-python-imports = ">=2.6.0"
+pre-commit-hooks = ">=4.0.1"
+sphinx-click = ">=3.0.2"
+Pygments = ">=2.10.0"
 furo = ">=2021.11.12"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Work around an issue where Dependabot always updates version constraints in pyproject.toml causing merge conflicts due to the updated content hash in poetry.lock.

- 🔧 [poetry] Remove upper version bounds for development dependencies
- 👷 [github] Prevent Dependabot from updating pyproject.toml

The drawback of this workaround is that we no longer receive automated updates for core dependencies outside of their version constraints. For now, I'm reluctant to remove upper bounds for those (even if [semver will not save you](https://hynek.me/articles/semver-will-not-save-you/)).

See https://github.com/dependabot/dependabot-core/issues/4435